### PR TITLE
Implement store locator page

### DIFF
--- a/locator.html
+++ b/locator.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Store Locator | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
 <body>
 <header class="navbar">
@@ -18,11 +19,30 @@
       <li><a href="login.html" >Login</a></li>
     </ul>
   </nav>
+  <a href="login.html" class="userIcon" aria-label="Account">👤</a>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:800px;margin:3rem auto;text-align:center">
-    <h1>Store Locator</h1>
-    <p>This page is coming soon.</p>
+  <main class="locatorWrap">
+    <h1 class="locatorTitle">Store Locator</h1>
+    <div class="filterRow">
+      <button class="filterBtn active">All</button>
+      <button class="filterBtn">Partnered</button>
+      <button class="filterBtn">Verified</button>
+    </div>
+    <div class="locatorGrid">
+      <div class="locatorSidebar">
+        <form id="locatorForm" class="searchForm">
+          <div class="searchBox">
+            <input type="text" id="locationInput" placeholder="City or ZIP" required>
+            <button type="submit">Find Stores</button>
+          </div>
+        </form>
+        <div id="storeResults" class="results"></div>
+      </div>
+      <div class="locatorMap">
+        <div id="map" class="map"></div>
+      </div>
+    </div>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">
@@ -57,6 +77,7 @@
   </div>
   <p class="copy">© <span id="year">2025</span> FindMySmokeShop. All rights reserved.</p>
 </footer>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -31,4 +31,111 @@ document.addEventListener('DOMContentLoaded', () => {
     prev.addEventListener('click', () => track.scrollBy({left:-cardWidth,behavior:'smooth'}));
     next.addEventListener('click', () => track.scrollBy({left: cardWidth,behavior:'smooth'}));
   }
+
+  const locForm = document.getElementById('locatorForm');
+  if (locForm) {
+    const results = document.getElementById('storeResults');
+    const mapEl = document.getElementById('map');
+    const map = L.map(mapEl).setView([37.09, -95.71], 4);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap'
+    }).addTo(map);
+    const markers = [];
+    const PARTNERED_IDS = ['PARTNER_ID_1', 'PARTNER_ID_2'];
+    const VERIFIED_IDS  = ['VERIFIED_ID_1', 'VERIFIED_ID_2'];
+    const filterBtns = document.querySelectorAll('.filterBtn');
+    let activeFilter = 'all';
+
+    filterBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        filterBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        activeFilter = btn.textContent.toLowerCase();
+        applyFilter();
+      });
+    });
+
+    locForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const loc = document.getElementById('locationInput').value.trim();
+      if (loc) fetchStores({near: loc});
+    });
+
+    const params = new URLSearchParams(location.search);
+    const q = params.get('q');
+    if (q) {
+      document.getElementById('locationInput').value = q;
+      fetchStores({near: q});
+    }
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(pos => {
+        const c = pos.coords;
+        fetchStores({ll: `${c.latitude},${c.longitude}`});
+      });
+    }
+
+    async function fetchStores(opts) {
+      results.textContent = 'Loading...';
+      try {
+        let lat, lon;
+        if (opts.near) {
+          const gUrl = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(opts.near)}&limit=1`;
+          const geo = await fetch(gUrl).then(r => r.json());
+          if (!geo.length) { results.textContent = 'Location not found.'; return; }
+          lat = geo[0].lat; lon = geo[0].lon;
+        }
+        if (opts.ll) {
+          [lat, lon] = opts.ll.split(',');
+        }
+        const radius = 10000;
+        const query = `[out:json];node["shop"="tobacco"](around:${radius},${lat},${lon});out;`;
+        const url = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query);
+        const data = await fetch(url).then(r => r.json());
+        showResults(data.elements || [], lat, lon);
+      } catch (err) {
+        results.textContent = 'Error loading stores.';
+      }
+    }
+
+    function showResults(stores, lat, lon) {
+      if (!stores.length) { results.textContent = 'No stores found.'; return; }
+      results.innerHTML = '';
+      markers.forEach(m => m.remove());
+      markers.length = 0;
+      map.setView([lat, lon], 12);
+      stores.forEach(s => {
+        const div = document.createElement('div');
+        const partnered = PARTNERED_IDS.includes(String(s.id));
+        const verified  = VERIFIED_IDS.includes(String(s.id));
+        div.className = 'storeItem';
+        div.dataset.partnered = partnered ? '1' : '0';
+        div.dataset.verified = verified ? '1' : '0';
+        let badge = '';
+        if (partnered) badge = '<span class="badge">Partner</span>';
+        else if (verified) badge = '<span class="badge badge-verified">Verified</span>';
+        const addressParts = [s.tags['addr:street'], s.tags['addr:city'], s.tags['addr:state'], s.tags['addr:postcode']].filter(Boolean);
+        const addr = addressParts.join(', ');
+        const name = s.tags.name || 'Smoke Shop';
+        div.innerHTML = `<strong>${name}</strong> ${badge}<br><small>${addr}</small>`;
+        results.appendChild(div);
+        if (s.lat && s.lon) {
+          const marker = L.marker([s.lat, s.lon]).addTo(map);
+          marker.bindPopup(div.innerHTML);
+          markers.push(marker);
+        }
+      });
+      applyFilter();
+    }
+
+    function applyFilter() {
+      const items = results.querySelectorAll('.storeItem');
+      items.forEach(it => {
+        let show = true;
+        if (activeFilter === 'partnered') show = it.dataset.partnered === '1';
+        if (activeFilter === 'verified') show = it.dataset.verified === '1';
+        it.style.display = show ? '' : 'none';
+      });
+    }
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,7 @@ img{display:block;max-width:100%}
 .navLinks a{color:var(--accent);font-weight:600;text-decoration:none;transition:opacity var(--dur);}
 .navLinks a:hover{opacity:.75}
 .navLinks .active{opacity:.55}
+.userIcon{color:#fff;font-size:1.4rem;margin-left:1rem;text-decoration:none;}
 .menuBtn{display:none;background:none;border:0;cursor:pointer;width:40px;height:32px;position:relative;margin-left:1rem}
 .menuBtn span,.menuBtn::before,.menuBtn::after{content:'';position:absolute;left:0;width:100%;height:4px;background:var(--accent);transition:var(--dur);}
 .menuBtn span{top:50%;transform:translateY(-50%)}
@@ -68,4 +69,23 @@ img{display:block;max-width:100%}
   .navLinks.open{display:flex}
   .navLinks a{width:100%;padding:.55rem 0}
   .productCard{flex:0 0 130px;height:130px}
+}
+
+/* ---- Locator ---- */
+.locatorWrap{max-width:var(--maxW);margin:2rem auto;padding:0 1rem;}
+.locatorTitle{font-size:2rem;margin:1.5rem 0;}
+.filterRow{display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:1rem;}
+.filterBtn{padding:.4rem 1rem;border-radius:999px;border:2px solid var(--accent);background:#fff;color:var(--accent);font-size:.9rem;cursor:pointer;transition:background var(--dur);}
+.filterBtn:hover{background:var(--accent);color:#fff}
+.filterBtn.active{background:var(--accent);color:#fff}
+.locatorGrid{display:grid;grid-template-columns:30% 70%;gap:1.5rem;align-items:start;}
+.locatorSidebar{display:flex;flex-direction:column;gap:1rem;}
+.results{display:flex;flex-direction:column;gap:.75rem;overflow-y:auto;max-height:calc(100vh - 260px);padding-right:.5rem}
+.storeItem{padding:1rem;border:2px solid #e0e0e0;border-radius:var(--radius);text-align:left;box-shadow:var(--shadow);background:#fff}
+.badge{background:var(--accent);color:#fff;border-radius:var(--radius);padding:.2rem .5rem;font-size:.75rem;margin-left:.4rem}
+.badge-verified{background:#5cb85c;color:#fff;border-radius:var(--radius);padding:.2rem .5rem;font-size:.75rem;margin-left:.4rem}
+.locatorMap .map{height:calc(100vh - 220px);width:100%;border-radius:var(--radius);overflow:hidden}
+@media(max-width:800px){
+  .locatorGrid{grid-template-columns:1fr}
+  .locatorMap .map{height:320px;margin-top:1rem}
 }


### PR DESCRIPTION
## Summary
- add Leaflet for an interactive store map
- embed map and results list in `locator.html`
- show partner badges and markers when fetching store data
- introduce a mobile-friendly two-column layout for locator page
- use open Overpass API for stores instead of Foursquare
- add filter buttons to toggle between all stores and partners
- mark verified shops with a green badge

## Testing
- `node -c script.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68851e648e548328acbd1526bd13e626