### PR TITLE
Move Foursquare API key to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Find My Smoke Shop
+
+This project is a simple website for locating smoke shops.
+
+## Setup
+
+1. Install [Node.js](https://nodejs.org/) if it is not already installed.
+2. Run `npm install` to install dependencies.
+3. Set the environment variable `FSQ_API_KEY` with your Foursquare API key.
+4. Start the application with `npm start` and visit `http://localhost:3000` in your browser.
+
+The API key is provided to the frontend via the `/api/config` endpoint. If the key is not set, the locator will display an error message.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "findmysmokeshop",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests defined\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const FSQ_API_KEY = process.env.FSQ_API_KEY || '';
+
+app.get('/api/config', (req, res) => {
+  res.json({ fsqApiKey: FSQ_API_KEY });
+});
+
+app.use(express.static(path.join(__dirname)));
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express server exposing `/api/config`
- update script.js to fetch API key from backend
- add `package.json` with start script
- document environment variable setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886887b600c8328b5feab1564a09484