### PR TITLE
Add default test logins and email contact flow

### DIFF
--- a/brand-dashboard.html
+++ b/brand-dashboard.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Retailer portal to update inventory and store details.">
-  <title>Retail Store Login | FindMySmokeShop</title>
+  <meta name="description" content="Brand dashboard to manage listings.">
+  <title>Brand Dashboard | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -21,29 +21,16 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:600px;margin:3rem auto;text-align:center">
-    <h1>Retail Store Login</h1>
-    <form id="retailLoginForm" class="login-form">
-      <div class="form-row">
-        <label>Email<br>
-          <input type="email" id="retailEmail" required>
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Password<br>
-          <input type="password" id="retailPassword" required>
-        </label>
-      </div>
-      <button type="submit" class="btn btn--primary">Log In</button>
-    </form>
-    <p class="small-text">Test account: <strong>store@test.com</strong> / <strong>test123</strong></p>
-    <p class="small-text">Store logins are provided only to confirmed retailers. <a href="contact.html">Contact us</a> to get verified.</p>
+  <main style="max-width:700px;margin:3rem auto;text-align:center" id="brandDashboard">
+    <h1>Welcome, <span class="user-email"></span></h1>
+    <p>This is a placeholder dashboard for brand partners.</p>
+    <button id="brandLogout" class="btn btn--primary">Log Out</button>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">
     <div class="footerCol">
       <h3>FindMySmokeShop</h3>
-      <p>Your one‑stop directory for smoke‑shop brands, products & local inventory.</p>
+      <p>Your one-stop directory for smoke-shop brands, products & local inventory.</p>
     </div>
     <div class="footerCol">
       <h4>Quick Links</h4>

--- a/brand-login.html
+++ b/brand-login.html
@@ -21,9 +21,23 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:800px;margin:3rem auto;text-align:center">
+  <main style="max-width:600px;margin:3rem auto;text-align:center">
     <h1>Brand Login</h1>
-    <p>This page is coming soon.</p>
+    <form id="brandLoginForm" class="login-form">
+      <div class="form-row">
+        <label>Email<br>
+          <input type="email" id="brandEmail" required>
+        </label>
+      </div>
+      <div class="form-row">
+        <label>Password<br>
+          <input type="password" id="brandPassword" required>
+        </label>
+      </div>
+      <button type="submit" class="btn btn--primary">Log In</button>
+    </form>
+    <p class="small-text">Test account: <strong>brand@test.com</strong> / <strong>test123</strong></p>
+    <p class="small-text">Accounts are created manually for verified brand partners. <a href="contact.html">Contact us</a> to request yours.</p>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">

--- a/contact.html
+++ b/contact.html
@@ -21,9 +21,28 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:800px;margin:3rem auto;text-align:center">
+  <main style="max-width:700px;margin:3rem auto;padding:0 1rem;text-align:center">
     <h1>Contact Us</h1>
-    <p>This page is coming soon.</p>
+    <p class="small-text">Submitting this form will open your email client to send your message to <strong>ecoelevation.owner@gmail.com</strong>. Use it to request a brand or store account so we can verify your business.</p>
+    <form id="contactForm" class="contact-form">
+      <div class="form-row">
+        <label>Name<br>
+          <input type="text" id="contactName" required>
+        </label>
+      </div>
+      <div class="form-row">
+        <label>Email<br>
+          <input type="email" id="contactEmail" required>
+        </label>
+      </div>
+      <div class="form-row">
+        <label>Message<br>
+          <textarea id="contactMessage" rows="4" required></textarea>
+        </label>
+      </div>
+      <button type="submit" class="btn btn--primary">Send</button>
+    </form>
+    <p id="contactStatus" style="margin-top:1rem;"></p>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">

--- a/login.html
+++ b/login.html
@@ -30,6 +30,7 @@
   <main class="loginWrap">
     <a href="brand-login.html"  class="loginBox"><h2>I’m a Brand</h2><p>Manage products, update logos, access analytics.</p></a>
     <a href="retail-login.html" class="loginBox"><h2>I’m a Retail Store</h2><p>Update inventory, claim your location, view lead stats.</p></a>
+    <p class="small-text" style="width:100%;text-align:center">Logins are granted by the site owner after verifying your business. <a href="contact.html">Contact us</a> to request access.</p>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">

--- a/retail-dashboard.html
+++ b/retail-dashboard.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Retailer portal to update inventory and store details.">
-  <title>Retail Store Login | FindMySmokeShop</title>
+  <meta name="description" content="Retail dashboard to manage store inventory.">
+  <title>Retail Dashboard | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -21,29 +21,16 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:600px;margin:3rem auto;text-align:center">
-    <h1>Retail Store Login</h1>
-    <form id="retailLoginForm" class="login-form">
-      <div class="form-row">
-        <label>Email<br>
-          <input type="email" id="retailEmail" required>
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Password<br>
-          <input type="password" id="retailPassword" required>
-        </label>
-      </div>
-      <button type="submit" class="btn btn--primary">Log In</button>
-    </form>
-    <p class="small-text">Test account: <strong>store@test.com</strong> / <strong>test123</strong></p>
-    <p class="small-text">Store logins are provided only to confirmed retailers. <a href="contact.html">Contact us</a> to get verified.</p>
+  <main style="max-width:700px;margin:3rem auto;text-align:center" id="retailDashboard">
+    <h1>Welcome, <span class="user-email"></span></h1>
+    <p>This is a placeholder dashboard for retail stores.</p>
+    <button id="retailLogout" class="btn btn--primary">Log Out</button>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">
     <div class="footerCol">
       <h3>FindMySmokeShop</h3>
-      <p>Your one‑stop directory for smoke‑shop brands, products & local inventory.</p>
+      <p>Your one-stop directory for smoke-shop brands, products & local inventory.</p>
     </div>
     <div class="footerCol">
       <h4>Quick Links</h4>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,21 @@ document.addEventListener('DOMContentLoaded', () => {
   const yr = document.getElementById('year');
   if (yr) yr.textContent = new Date().getFullYear();
 
+  // Seed default accounts for testing if none exist
+  const seedDefaults = () => {
+    if (!localStorage.getItem('brandAccounts')) {
+      localStorage.setItem('brandAccounts', JSON.stringify({
+        'brand@test.com': { password: 'test123' }
+      }));
+    }
+    if (!localStorage.getItem('retailAccounts')) {
+      localStorage.setItem('retailAccounts', JSON.stringify({
+        'store@test.com': { password: 'test123' }
+      }));
+    }
+  };
+  seedDefaults();
+
   const search  = document.getElementById('brandSearch');
   const select  = document.getElementById('categoryFilter');
   if (search && select) {
@@ -141,4 +156,104 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
   }
+
+  // ----- Simple Login Handling -----
+  const brandForm = document.getElementById('brandLoginForm');
+  if (brandForm) {
+    if (localStorage.getItem('brandLoggedIn')) {
+      window.location.href = 'brand-dashboard.html';
+    }
+    brandForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const email = document.getElementById('brandEmail').value.trim();
+      const pass = document.getElementById('brandPassword').value;
+      const accounts = JSON.parse(localStorage.getItem('brandAccounts') || '{}');
+      if (accounts[email] && accounts[email].password === pass) {
+        localStorage.setItem('brandLoggedIn', email);
+        window.location.href = 'brand-dashboard.html';
+      } else {
+        alert('Invalid credentials. Please contact us to request access.');
+      }
+      brandForm.reset();
+    });
+  }
+
+  const retailForm = document.getElementById('retailLoginForm');
+  if (retailForm) {
+    if (localStorage.getItem('retailLoggedIn')) {
+      window.location.href = 'retail-dashboard.html';
+    }
+    retailForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const email = document.getElementById('retailEmail').value.trim();
+      const pass = document.getElementById('retailPassword').value;
+      const accounts = JSON.parse(localStorage.getItem('retailAccounts') || '{}');
+      if (accounts[email] && accounts[email].password === pass) {
+        localStorage.setItem('retailLoggedIn', email);
+        window.location.href = 'retail-dashboard.html';
+      } else {
+        alert('Invalid credentials. Please contact us to request access.');
+      }
+      retailForm.reset();
+    });
+  }
+
+  const contactForm = document.getElementById('contactForm');
+  if (contactForm) {
+    contactForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const name = document.getElementById('contactName').value.trim();
+      const email = document.getElementById('contactEmail').value.trim();
+      const msg = document.getElementById('contactMessage').value.trim();
+      const status = document.getElementById('contactStatus');
+      const body = encodeURIComponent(`Name: ${name}\nEmail: ${email}\n\n${msg}`);
+      window.location.href = `mailto:ecoelevation.owner@gmail.com?subject=Account%20Request&body=${body}`;
+      if (status) {
+        status.textContent = 'Opening your email client...';
+      }
+      contactForm.reset();
+    });
+  }
+
+  // ----- Dashboard handling -----
+  const brandDash = document.getElementById('brandDashboard');
+  if (brandDash) {
+    const email = localStorage.getItem('brandLoggedIn');
+    if (!email) {
+      window.location.href = 'brand-login.html';
+    } else {
+      brandDash.querySelector('.user-email').textContent = email;
+      document.getElementById('brandLogout').addEventListener('click', () => {
+        localStorage.removeItem('brandLoggedIn');
+        window.location.href = 'brand-login.html';
+      });
+    }
+  }
+
+  const retailDash = document.getElementById('retailDashboard');
+  if (retailDash) {
+    const email = localStorage.getItem('retailLoggedIn');
+    if (!email) {
+      window.location.href = 'retail-login.html';
+    } else {
+      retailDash.querySelector('.user-email').textContent = email;
+      document.getElementById('retailLogout').addEventListener('click', () => {
+        localStorage.removeItem('retailLoggedIn');
+        window.location.href = 'retail-login.html';
+      });
+    }
+  }
+
+  // Utility functions for adding accounts manually via browser console
+  window.createBrandAccount = (email, password) => {
+    const accounts = JSON.parse(localStorage.getItem('brandAccounts') || '{}');
+    accounts[email] = { password };
+    localStorage.setItem('brandAccounts', JSON.stringify(accounts));
+  };
+
+  window.createRetailAccount = (email, password) => {
+    const accounts = JSON.parse(localStorage.getItem('retailAccounts') || '{}');
+    accounts[email] = { password };
+    localStorage.setItem('retailAccounts', JSON.stringify(accounts));
+  };
 });

--- a/styles.css
+++ b/styles.css
@@ -93,3 +93,13 @@ img{display:block;max-width:100%}
 .userIcon svg{width:28px;height:28px}
 .geoMessage{color:#b00;margin-top:.75rem;font-size:.9rem}
 @media(max-width:800px){.locatorGrid{flex-direction:column}.locatorList{flex:0 0 auto}}
+
+/* ---- Forms ---- */
+.login-form,.contact-form{display:flex;flex-direction:column;gap:1rem;margin-top:1.5rem}
+.login-form input,.contact-form input,.contact-form textarea{width:100%;padding:.6rem .8rem;border:2px solid #ccc;border-radius:var(--radius);font-size:1rem}
+.login-form button,.contact-form button{align-self:center;padding:.6rem 1.5rem;font-size:1rem;font-weight:600;border:0;border-radius:var(--radius);background:var(--accent);color:#fff;cursor:pointer;transition:opacity var(--dur)}
+.login-form button:hover,.contact-form button:hover{opacity:.85}
+.small-text{margin-top:1rem;font-size:.9rem}
+
+/* ---- Dashboard ---- */
+#brandDashboard,#retailDashboard{padding:2rem 1rem}


### PR DESCRIPTION
## Summary
- seed localStorage with demo brand and retail accounts
- show test credentials on the login pages
- inform users the contact form opens an email to request accounts
- open a `mailto:` link on contact form submit
- clarify that account creation is manual and requires verification

## Testing
- `npx --yes prettier -w login.html brand-login.html brand-dashboard.html retail-login.html retail-dashboard.html contact.html script.js styles.css` *(formatting only; reverted)*
- `python3 -m http.server` *(fails: address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6886907060988328bbb560ac23735651