### PR TITLE
Add simple brand and store dashboards

### DIFF
--- a/brand-portal.html
+++ b/brand-portal.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Brand dashboard to manage products and view analytics.">
+  <title>Brand Dashboard | FindMySmokeShop</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .infoWrap{max-width:860px;margin:3rem auto;padding:0 1rem;}
+    .infoWrap h1{text-align:center;font-size:2rem;margin-bottom:1.2rem;}
+    .infoWrap ul{line-height:1.6;margin-left:1.2rem;}
+  </style>
+</head>
+<body id="brandPortal">
+<header class="navbar">
+  <a href="index.html" class="brand">
+    <img src="https://cdn1.site-media.eu/images/0/17873942/full-logo-trasnparent-bg-usB-Tiu-NwyR5pEhcKXtxQ.png" alt="logo" width="110">
+  </a>
+  <nav role="navigation">
+    <ul class="navLinks" id="navLinks">
+      <li><a href="brands.html" >Brands</a></li>
+      <li><a href="for-shops.html">For Stores</a></li>
+      <li><a href="login.html" >Login</a></li>
+    </ul>
+  </nav>
+  <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
+</header>
+  <main class="infoWrap">
+    <h1>Brand Dashboard</h1>
+    <ul>
+      <li><strong>Manage Products:</strong> add or edit your product listings.</li>
+      <li><strong>Update Brand Assets:</strong> upload new logos and images.</li>
+      <li><strong>View Analytics:</strong> see store leads and brand views.</li>
+    </ul>
+    <p style="margin-top:2rem;text-align:center;">
+      <button id="brandLogout" class="btn btn--secondary">Log Out</button>
+    </p>
+  </main>
+<footer class="siteFooter">
+  <div class="footerInner">
+    <div class="footerCol">
+      <h3>FindMySmokeShop</h3>
+      <p>Your one‑stop directory for smoke‑shop brands, products & local inventory.</p>
+    </div>
+    <div class="footerCol">
+      <h4>Quick Links</h4>
+      <ul class="footerLinks">
+        <li><a href="brands.html">Brands</a></li>
+        <li><a href="for-shops.html">For Stores</a></li>
+        <li><a href="locator.html">Store Locator</a></li>
+        <li><a href="contact.html">Contact Us</a></li>
+      </ul>
+    </div>
+    <div class="footerCol">
+      <h4>Legal</h4>
+      <ul class="footerLinks">
+        <li><a href="terms.html">Terms of Use</a></li>
+        <li><a href="privacy.html">Privacy Policy</a></li>
+      </ul>
+    </div>
+    <div class="footerCol">
+      <h4>Follow Us</h4>
+      <div class="socialWrap">
+        <a href="#" aria-label="Instagram"></a>
+        <a href="#" aria-label="Facebook"></a>
+        <a href="#" aria-label="Twitter"></a>
+      </div>
+    </div>
+  </div>
+  <p class="copy">© <span id="year">2025</span> FindMySmokeShop. All rights reserved.</p>
+</footer>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/retail-portal.html
+++ b/retail-portal.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Retail dashboard to manage your store profile and inventory.">
+  <title>Store Dashboard | FindMySmokeShop</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .infoWrap{max-width:860px;margin:3rem auto;padding:0 1rem;}
+    .infoWrap h1{text-align:center;font-size:2rem;margin-bottom:1.2rem;}
+    .infoWrap ul{line-height:1.6;margin-left:1.2rem;}
+  </style>
+</head>
+<body id="retailPortal">
+<header class="navbar">
+  <a href="index.html" class="brand">
+    <img src="https://cdn1.site-media.eu/images/0/17873942/full-logo-trasnparent-bg-usB-Tiu-NwyR5pEhcKXtxQ.png" alt="logo" width="110">
+  </a>
+  <nav role="navigation">
+    <ul class="navLinks" id="navLinks">
+      <li><a href="brands.html" >Brands</a></li>
+      <li><a href="for-shops.html">For Stores</a></li>
+      <li><a href="login.html" >Login</a></li>
+    </ul>
+  </nav>
+  <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
+</header>
+  <main class="infoWrap">
+    <h1>Store Dashboard</h1>
+    <ul>
+      <li><strong>Update Inventory:</strong> manage the products you carry.</li>
+      <li><strong>Claim or Update Location:</strong> edit store details and hours.</li>
+      <li><strong>View Lead Stats:</strong> track customer inquiries and visits.</li>
+    </ul>
+    <p style="margin-top:2rem;text-align:center;">
+      <button id="retailLogout" class="btn btn--secondary">Log Out</button>
+    </p>
+  </main>
+<footer class="siteFooter">
+  <div class="footerInner">
+    <div class="footerCol">
+      <h3>FindMySmokeShop</h3>
+      <p>Your one‑stop directory for smoke‑shop brands, products & local inventory.</p>
+    </div>
+    <div class="footerCol">
+      <h4>Quick Links</h4>
+      <ul class="footerLinks">
+        <li><a href="brands.html">Brands</a></li>
+        <li><a href="for-shops.html">For Stores</a></li>
+        <li><a href="locator.html">Store Locator</a></li>
+        <li><a href="contact.html">Contact Us</a></li>
+      </ul>
+    </div>
+    <div class="footerCol">
+      <h4>Legal</h4>
+      <ul class="footerLinks">
+        <li><a href="terms.html">Terms of Use</a></li>
+        <li><a href="privacy.html">Privacy Policy</a></li>
+      </ul>
+    </div>
+    <div class="footerCol">
+      <h4>Follow Us</h4>
+      <div class="socialWrap">
+        <a href="#" aria-label="Instagram"></a>
+        <a href="#" aria-label="Facebook"></a>
+        <a href="#" aria-label="Twitter"></a>
+      </div>
+    </div>
+  </div>
+  <p class="copy">© <span id="year">2025</span> FindMySmokeShop. All rights reserved.</p>
+</footer>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -153,7 +153,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const pass = document.getElementById('brandPassword').value;
       const accounts = JSON.parse(localStorage.getItem('brandAccounts') || '{}');
       if (accounts[email] && accounts[email].password === pass) {
-        alert('Login successful.');
+        localStorage.setItem('brandLoggedIn','true');
+        window.location.href = 'brand-portal.html';
       } else {
         alert('Invalid credentials. Please contact us to request access.');
       }
@@ -169,7 +170,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const pass = document.getElementById('retailPassword').value;
       const accounts = JSON.parse(localStorage.getItem('retailAccounts') || '{}');
       if (accounts[email] && accounts[email].password === pass) {
-        alert('Login successful.');
+        localStorage.setItem('retailLoggedIn','true');
+        window.location.href = 'retail-portal.html';
       } else {
         alert('Invalid credentials. Please contact us to request access.');
       }
@@ -199,4 +201,28 @@ document.addEventListener('DOMContentLoaded', () => {
     accounts[email] = { password };
     localStorage.setItem('retailAccounts', JSON.stringify(accounts));
   };
+
+  // ----- Portal Auth Checks -----
+  const brandPortal = document.getElementById('brandPortal');
+  if (brandPortal && !localStorage.getItem('brandLoggedIn')) {
+    window.location.href = 'brand-login.html';
+  }
+  const brandLogout = document.getElementById('brandLogout');
+  if (brandLogout) {
+    brandLogout.addEventListener('click', () => {
+      localStorage.removeItem('brandLoggedIn');
+      window.location.href = 'brand-login.html';
+    });
+  }
+  const retailPortal = document.getElementById('retailPortal');
+  if (retailPortal && !localStorage.getItem('retailLoggedIn')) {
+    window.location.href = 'retail-login.html';
+  }
+  const retailLogout = document.getElementById('retailLogout');
+  if (retailLogout) {
+    retailLogout.addEventListener('click', () => {
+      localStorage.removeItem('retailLoggedIn');
+      window.location.href = 'retail-login.html';
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add placeholder dashboard pages for brands and retailers
- update login JS to redirect to dashboards and handle logout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68869a9625848328812508ffb97e3da5