### PR TITLE
Refactor inline styles into reusable classes

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:700px;margin:3rem auto;text-align:center">
+  <main class="main-centered">
     <h1>Page Not Found</h1>
     <p>The page you’re looking for doesn’t exist.</p>
     <p><a href="index.html" class="btn btn--primary">Back to Home</a></p>

--- a/brand-login.html
+++ b/brand-login.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:600px;margin:3rem auto;text-align:center">
+  <main class="main-centered main-centered--sm">
     <h1>Brand Login</h1>
     <form id="brandLoginForm" class="login-form">
       <div class="form-row">

--- a/brand-portal.html
+++ b/brand-portal.html
@@ -6,11 +6,6 @@
   <meta name="description" content="Brand dashboard to manage products and view analytics.">
   <title>Brand Dashboard | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
-  <style>
-    .infoWrap{max-width:860px;margin:3rem auto;padding:0 1rem;}
-    .infoWrap h1{text-align:center;font-size:2rem;margin-bottom:1.2rem;}
-    .infoWrap ul{line-height:1.6;margin-left:1.2rem;}
-  </style>
 </head>
 <body id="brandPortal">
 <header class="navbar">
@@ -33,7 +28,7 @@
       <li><strong>Update Brand Assets:</strong> upload new logos and images.</li>
       <li><strong>View Analytics:</strong> see store leads and brand views.</li>
     </ul>
-    <p style="margin-top:2rem;text-align:center;">
+    <p class="centered-block">
       <button id="brandLogout" class="btn btn--secondary">Log Out</button>
     </p>
   </main>

--- a/brands.html
+++ b/brands.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <section class="filterBar" style="max-width:var(--maxW);margin:2rem auto;padding:0 1rem;text-align:center">
+  <section class="filterBar">
     <label for="brandSearch" class="visually-hidden">Search brand name</label>
     <input type="search" id="brandSearch" placeholder="Search brand name…">
     <select id="categoryFilter">
@@ -31,7 +31,7 @@
       <option value="accessories">Accessories</option>
     </select>
   </section>
-  <section class="brandGrid" id="brandGrid" style="max-width:var(--maxW);margin:0 auto 3rem;padding:0 1rem;display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:1.5rem;justify-items:center">
+  <section class="brandGrid" id="brandGrid">
     <a href="locator.html?q=RAW" class="brandCard" data-cat="accessories"><img src="images/logo-raw.png" alt="RAW logo"><span>RAW</span></a>
     <a href="locator.html?q=Puffco" class="brandCard" data-cat="vape"><img src="images/logo-puffco.png" alt="Puffco logo"><span>Puffco</span></a>
     <a href="locator.html?q=Stundenglass" class="brandCard" data-cat="glass"><img src="images/logo-stundenglass.png" alt="Stundenglass logo"><span>Stündenglass</span></a>

--- a/contact.html
+++ b/contact.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:700px;margin:3rem auto;padding:0 1rem;text-align:center">
+  <main class="main-centered padded">
     <h1>Contact Us</h1>
     <form id="contactForm" class="contact-form">
       <div class="form-row">
@@ -41,7 +41,7 @@
       </div>
       <button type="submit" class="btn btn--primary">Send</button>
     </form>
-    <p id="contactStatus" style="margin-top:1rem;"></p>
+    <p id="contactStatus" class="mt-1"></p>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">

--- a/for-shops.html
+++ b/for-shops.html
@@ -6,11 +6,6 @@
   <meta name="description" content="Learn how listing your shop boosts visibility and unlocks exclusive deals.">
   <title>For Stores | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
-  <style>
-    .infoWrap{max-width:860px;margin:3rem auto;padding:0 1rem;}
-    .infoWrap h1{text-align:center;font-size:2rem;margin-bottom:1.2rem;}
-    .infoWrap ul{line-height:1.6;margin-left:1.2rem;}
-  </style>
 </head>
 <body>
 <header class="navbar">
@@ -34,7 +29,7 @@
       <li><strong>Exclusive Deals:</strong> first‑look wholesale pricing from top brands.</li>
       <li><strong>Priority Ranking:</strong> partnered stores outrank others in search & map.</li>
     </ul>
-    <p style="margin-top:2rem;text-align:center;">
+    <p class="centered-block">
       <a href="retail-login.html" class="btn btn--primary">Get Started</a>
     </p>
   </main>

--- a/learn-more.html
+++ b/learn-more.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:800px;margin:3rem auto;text-align:center">
+  <main class="main-centered main-centered--lg">
     <h1>Learn More</h1>
     <p>FindMySmokeShop lets you locate smoke shops by city, zip code or product
       search. Browse featured brands and discover new items in one place.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:800px;margin:3rem auto;text-align:center">
+  <main class="main-centered main-centered--lg">
     <h1>Privacy Policy</h1>
     <p>We value your privacy and only collect personal details you choose to
       provide, such as when you submit a form or search for nearby shops.</p>

--- a/retail-login.html
+++ b/retail-login.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:600px;margin:3rem auto;text-align:center">
+  <main class="main-centered main-centered--sm">
     <h1>Retail Store Login</h1>
     <form id="retailLoginForm" class="login-form">
       <div class="form-row">

--- a/retail-portal.html
+++ b/retail-portal.html
@@ -6,11 +6,6 @@
   <meta name="description" content="Retail dashboard to manage your store profile and inventory.">
   <title>Store Dashboard | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
-  <style>
-    .infoWrap{max-width:860px;margin:3rem auto;padding:0 1rem;}
-    .infoWrap h1{text-align:center;font-size:2rem;margin-bottom:1.2rem;}
-    .infoWrap ul{line-height:1.6;margin-left:1.2rem;}
-  </style>
 </head>
 <body id="retailPortal">
 <header class="navbar">
@@ -33,7 +28,7 @@
       <li><strong>Claim or Update Location:</strong> edit store details and hours.</li>
       <li><strong>View Lead Stats:</strong> track customer inquiries and visits.</li>
     </ul>
-    <p style="margin-top:2rem;text-align:center;">
+    <p class="centered-block">
       <button id="retailLogout" class="btn btn--secondary">Log Out</button>
     </p>
   </main>

--- a/styles.css
+++ b/styles.css
@@ -100,3 +100,15 @@ img{display:block;max-width:100%}
 .login-form button,.contact-form button{align-self:center;padding:.6rem 1.5rem;font-size:1rem;font-weight:600;border:0;border-radius:var(--radius);background:var(--accent);color:#fff;cursor:pointer;transition:opacity var(--dur)}
 .login-form button:hover,.contact-form button:hover{opacity:.85}
 .small-text{margin-top:1rem;font-size:.9rem}
+/* ---- Utility ---- */
+.main-centered{max-width:700px;margin:3rem auto;text-align:center;}
+.main-centered--sm{max-width:600px;}
+.main-centered--lg{max-width:800px;}
+.padded{padding:0 1rem;}
+.infoWrap{max-width:860px;margin:3rem auto;padding:0 1rem;}
+.infoWrap h1{text-align:center;font-size:2rem;margin-bottom:1.2rem;}
+.infoWrap ul{line-height:1.6;margin-left:1.2rem;}
+.centered-block{margin-top:2rem;text-align:center;}
+.mt-1{margin-top:1rem;}
+.filterBar{max-width:var(--maxW);margin:2rem auto;padding:0 1rem;text-align:center;}
+.brandGrid{max-width:var(--maxW);margin:0 auto 3rem;padding:0 1rem;display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:1.5rem;justify-items:center;}

--- a/terms.html
+++ b/terms.html
@@ -21,7 +21,7 @@
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main style="max-width:800px;margin:3rem auto;text-align:center">
+  <main class="main-centered main-centered--lg">
     <h1>Terms of Use</h1>
     <p>By accessing FindMySmokeShop you agree to use the directory only for
       lawful purposes and in accordance with these terms.</p>


### PR DESCRIPTION
## Summary
- centralize repeated layout rules in `styles.css`
- remove inline styles in various pages and apply new classes
- share `infoWrap` layout across portal pages
- clean up brand listing markup

## Testing
- `grep -n "style=" -r *.html`

------
https://chatgpt.com/codex/tasks/task_e_68869d7b908083288af2b9d08b2adf7d