### PR TITLE
Improve sign-up and add subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules/
 venv/
 __pycache__/
+app.db

--- a/404.html
+++ b/404.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # FindMySmokeShop
 
-A simple static website for locating smoke shops and browsing popular smoke‑shop brands. The project contains only HTML, CSS and a small amount of JavaScript for interactive features and for calling the Foursquare Places API.
+A simple static website for locating smoke shops and browsing popular smoke‑shop brands. The project contains only HTML, CSS and a small amount of JavaScript for interactive features and for calling a small Flask API.
+
+Visitors will see an age verification popup on first load. They must confirm they are 21 or older to access the pages. The choice is stored in `localStorage` so the prompt only appears once per browser.
 
 ## Serving the site locally
 
@@ -12,15 +14,9 @@ python3 -m http.server
 
 Then open `http://localhost:8000` in your browser and navigate to the HTML pages.
 
-## Foursquare API key
+## Google Maps API key
 
-The store locator in `locator.html` fetches nearby shops using the Foursquare Places API. The key is defined in [`script.js`](script.js) as the constant `FSQ_API_KEY`:
-
-```javascript
-const FSQ_API_KEY = 'YOUR_FOURSQUARE_API_KEY';
-```
-
-Replace the placeholder value with your actual API key before using the locator page.
+Store searches now proxy to the Google Maps Places API through the Flask backend. Set the `GOOGLE_MAPS_API_KEY` environment variable before running the server so your key isn't exposed to the browser.
 
 ## Login credentials
 
@@ -28,8 +24,11 @@ Brand and retailer logins use credentials stored in the browser's
 `localStorage`. This approach is meant only for demo/testing purposes and is
 not secure for real accounts.
 
+Visitors can create an account from `signup.html`. New accounts are marked as
+pending until you approve them in the SQLite database. Logging in before
+approval will return an "Account pending approval" error.
 
-v4sahf-codex/find-namecheap-hosted-app-options
+
 
 ## Python backend
 
@@ -64,26 +63,29 @@ a SQLite database stored alongside the code.
 - `GET /me` – return the logged in user's email and subscription status.
 - `POST /subscribe` – update subscription status with body `{ "status": "..." }`.
 
+The brand and retail portals contain a small form that lets logged in users
+update their subscription level using the `/subscribe` endpoint.
+
 Set `SECRET_KEY` in `backend/app.py` to a strong value before deploying.
 
-## Deploying with Git on Namecheap
+## Deploying with cPanel Git
 
-Namecheap's cPanel includes a **Git Version Control** feature that can automatically pull your repository and run deployment commands.
+cPanel includes a **Git Version Control** feature that can automatically pull your repository and run deployment commands.
 
 1. Log in to cPanel and open **Git Version Control**.
 2. Click **Create** and choose a repository path such as `~/repos/findmysmokeshop.git`. If your code is hosted elsewhere, provide the clone URL.
 3. cPanel will display an SSH address. On your local machine, add it as a remote:
 
    ```bash
-   git remote add namecheap ssh://USERNAME@HOSTNAME/home/USERNAME/repos/findmysmokeshop.git
+   git remote add cpanel ssh://USERNAME@HOSTNAME/home/USERNAME/repos/findmysmokeshop.git
    ```
 
    Replace `USERNAME` and `HOSTNAME` with your account details.
 
-4. Push your code to Namecheap:
+4. Push your code to cPanel:
 
    ```bash
-   git push namecheap main
+   git push cpanel main
    ```
 
 5. To deploy automatically, add a `.cpanel.yml` file with instructions:
@@ -99,27 +101,4 @@ Namecheap's cPanel includes a **Git Version Control** feature that can automatic
 6. Enable deployment in cPanel's Git interface. Each push will run the commands from `.cpanel.yml`.
 
 7. If using the Flask backend, create a Python app in cPanel's **Setup Python App** and set its project path to the `backend/` directory. Restart the app after updates.
-
-=======
-## Python backend
-
-A minimal Flask application is provided in `app.py` for handling user registration, login and basic subscription storage. It uses SQLite for persistence and exposes JSON API endpoints under `/api/*`.
-
-### Setup
-
-1. Install dependencies in a virtual environment:
-
-```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-```
-
-2. Run the server locally:
-
-```bash
-python app.py
-```
-
-The application will create `app.db` on first start. API requests can be sent from the frontend using `fetch()`.
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import sqlite3
-from flask import Flask, request, jsonify, session
+import os
+import requests
+from flask import Flask, request, jsonify, session, Response
 from flask_cors import CORS
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -8,6 +10,7 @@ app.config['SECRET_KEY'] = 'change-this-secret-key'
 CORS(app, supports_credentials=True)
 
 DATABASE = 'app.db'
+GOOGLE_MAPS_API_KEY = os.environ.get('GOOGLE_MAPS_API_KEY')
 
 def get_db():
     conn = sqlite3.connect(DATABASE)
@@ -85,6 +88,52 @@ def subscribe():
     finally:
         conn.close()
     return jsonify({'message': 'Subscribed successfully'})
+
+@app.route('/api/stores')
+def stores():
+    if not GOOGLE_MAPS_API_KEY:
+        return jsonify({'error': 'API key not configured'}), 500
+    near = request.args.get('near')
+    ll = request.args.get('ll')
+    params = {'key': GOOGLE_MAPS_API_KEY}
+    if near:
+        url = 'https://maps.googleapis.com/maps/api/place/textsearch/json'
+        params['query'] = f'smoke shop in {near}'
+    elif ll:
+        url = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json'
+        params['location'] = ll
+        params['radius'] = '10000'
+        params['keyword'] = 'smoke shop'
+    else:
+        return jsonify([])
+    if request.args.get('open'):
+        params['opennow'] = 'true'
+    r = requests.get(url, params=params, timeout=5)
+    data = r.json()
+    results = []
+    for item in data.get('results', []):
+        loc = item.get('geometry', {}).get('location', {})
+        results.append({
+            'place_id': item.get('place_id'),
+            'name': item.get('name'),
+            'address': item.get('formatted_address') or item.get('vicinity'),
+            'lat': loc.get('lat'),
+            'lng': loc.get('lng')
+        })
+    return jsonify(results)
+
+@app.route('/api/static-map')
+def static_map():
+    if not GOOGLE_MAPS_API_KEY:
+        return jsonify({'error': 'API key not configured'}), 500
+    markers = request.args.getlist('marker')
+    if not markers:
+        return jsonify({'error': 'No markers'}), 400
+    params = [('size', '640x400'), ('key', GOOGLE_MAPS_API_KEY)]
+    for m in markers:
+        params.append(('markers', m))
+    r = requests.get('https://maps.googleapis.com/maps/api/staticmap', params=params, timeout=5)
+    return Response(r.content, content_type=r.headers.get('Content-Type', 'image/png'))
 
 if __name__ == '__main__':
     init_db()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 Flask-Cors
+requests

--- a/brand-login.html
+++ b/brand-login.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>
@@ -37,7 +38,7 @@
       </div>
       <button type="submit" class="btn btn--primary">Log In</button>
     </form>
-    <p class="small-text">Need an account? <a href="contact.html">Contact us</a> to request access.</p>
+    <p class="small-text">Need an account? <a href="signup.html">Sign up</a>.</p>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">

--- a/brand-portal.html
+++ b/brand-portal.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html">For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>
@@ -29,6 +30,16 @@
       <li><strong>Update Brand Assets:</strong> upload new logos and images.</li>
       <li><strong>View Analytics:</strong> see store leads and brand views.</li>
     </ul>
+    <form id="subForm" class="subscriptionForm">
+      <label>Subscription
+        <select id="subSelect">
+          <option value="none">None</option>
+          <option value="basic">Basic</option>
+          <option value="premium">Premium</option>
+        </select>
+      </label>
+      <button type="submit" class="btn btn--primary">Update</button>
+    </form>
     <p class="centered-block">
       <button id="brandLogout" class="btn btn--secondary">Log Out</button>
     </p>

--- a/brands.html
+++ b/brands.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" class="active">Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/for-shops.html
+++ b/for-shops.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" class="active">For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/learn-more.html
+++ b/learn-more.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/locator.html
+++ b/locator.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html">Brands</a></li>
       <li><a href="for-shops.html">For Stores</a></li>
       <li><a href="locator.html" class="active">Store Locator</a></li>
@@ -44,7 +45,7 @@
       <div id="storeResults" class="results"></div>
     </div>
     <div class="locatorMap">
-      <div id="map" class="mapArea">Map Placeholder</div>
+      <img id="mapImage" class="mapArea" alt="Map showing store locations" src="" />
     </div>
   </main>
 <footer class="siteFooter">

--- a/login.html
+++ b/login.html
@@ -20,6 +20,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/privacy.html
+++ b/privacy.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 Flask-Cors
 Werkzeug
+requests

--- a/retail-login.html
+++ b/retail-login.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>
@@ -37,7 +38,7 @@
       </div>
       <button type="submit" class="btn btn--primary">Log In</button>
     </form>
-    <p class="small-text">Need an account? <a href="contact.html">Contact us</a> to request access.</p>
+    <p class="small-text">Need an account? <a href="signup.html">Sign up</a>.</p>
   </main>
 <footer class="siteFooter">
   <div class="footerInner">

--- a/retail-portal.html
+++ b/retail-portal.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html">For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>
@@ -29,6 +30,16 @@
       <li><strong>Claim or Update Location:</strong> edit store details and hours.</li>
       <li><strong>View Lead Stats:</strong> track customer inquiries and visits.</li>
     </ul>
+    <form id="subForm" class="subscriptionForm">
+      <label>Subscription
+        <select id="subSelect">
+          <option value="none">None</option>
+          <option value="basic">Basic</option>
+          <option value="premium">Premium</option>
+        </select>
+      </label>
+      <button type="submit" class="btn btn--primary">Update</button>
+    </form>
     <p class="centered-block">
       <button id="retailLogout" class="btn btn--secondary">Log Out</button>
     </p>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
+  if (!localStorage.getItem('ageVerified')) {
+    const gate = document.createElement('div');
+    gate.id = 'ageGate';
+    gate.innerHTML = `
+      <div class="ageGateBox">
+        <p>You must be 21 or older to enter this site.</p>
+        <button id="ageConfirm" class="btn btn--primary">I am 21 or older</button>
+      </div>`;
+    document.body.appendChild(gate);
+    document.getElementById('ageConfirm').addEventListener('click', () => {
+      localStorage.setItem('ageVerified', 'true');
+      location.reload();
+    });
+    return;
+  }
   const menuBtn  = document.getElementById('menuBtn');
   const navLinks = document.getElementById('navLinks');
   if (menuBtn) menuBtn.addEventListener('click', () => navLinks.classList.toggle('open'));
@@ -35,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const locForm = document.getElementById('locatorForm');
   if (locForm) {
     const results = document.getElementById('storeResults');
-    const FSQ_API_KEY = 'YOUR_FOURSQUARE_API_KEY';
+    const mapImg  = document.getElementById('mapImage');
     const PARTNERED_IDS = ['PARTNER_ID_1', 'PARTNER_ID_2'];
 
     const params = new URLSearchParams(window.location.search);
@@ -87,29 +102,31 @@ document.addEventListener('DOMContentLoaded', () => {
     async function fetchStores(opts) {
       lastOpts = opts;
       results.textContent = 'Loading...';
+      if (mapImg) mapImg.src = '';
       try {
-        const url = new URL('https://api.foursquare.com/v3/places/search');
-        url.searchParams.set('query', 'smoke shop');
-        url.searchParams.set('limit', '20');
-        if (activeFilter === 'open') url.searchParams.set('open_now', 'true');
+        const url = new URL('/api/stores', window.location.origin);
+        if (activeFilter === 'open') url.searchParams.set('open', '1');
         if (opts.near) url.searchParams.set('near', opts.near);
-        if (opts.ll) {
-          url.searchParams.set('ll', opts.ll);
-          url.searchParams.set('radius', '10000');
-        }
-
-        const resp = await fetch(url.toString(), {
-          headers: { 'Accept': 'application/json', 'Authorization': FSQ_API_KEY }
-        });
+        if (opts.ll) url.searchParams.set('ll', opts.ll);
+        const resp = await fetch(url.toString());
         const data = await resp.json();
-        let stores = data.results || [];
+        let stores = data;
         if (activeFilter === 'partnered') {
-          stores = stores.filter(s => PARTNERED_IDS.includes(s.fsq_id));
+          stores = stores.filter(s => PARTNERED_IDS.includes(s.place_id));
         }
         showResults(stores);
+        updateMap(stores);
       } catch (err) {
         results.textContent = 'Error loading stores.';
       }
+    }
+
+    function updateMap(stores) {
+      if (!mapImg) return;
+      if (!stores.length) { mapImg.alt = 'No stores found'; mapImg.src = ''; return; }
+      const params = new URLSearchParams();
+      stores.forEach(s => params.append('marker', `${s.lat},${s.lng}`));
+      mapImg.src = `/api/static-map?${params.toString()}`;
     }
 
     function showResults(stores) {
@@ -123,7 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
         nameEl.textContent = s.name || '';
         div.appendChild(nameEl);
 
-        if (PARTNERED_IDS.includes(s.fsq_id)) {
+        if (PARTNERED_IDS.includes(s.place_id)) {
           div.appendChild(document.createTextNode(' '));
           const badge = document.createElement('span');
           badge.className = 'badge';
@@ -134,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
         div.appendChild(document.createElement('br'));
 
         const addr = document.createElement('small');
-        addr.textContent = s.location.formatted_address || '';
+        addr.textContent = s.address || '';
         div.appendChild(addr);
 
         results.appendChild(div);
@@ -198,6 +215,31 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const signupForm = document.getElementById('signupForm');
+  if (signupForm) {
+    signupForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const email = document.getElementById('signupEmail').value.trim();
+      const pass = document.getElementById('signupPassword').value;
+      try {
+        const resp = await fetch('/api/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: pass })
+        });
+        if (resp.ok) {
+          signupForm.innerHTML =
+            '<p>Thanks for signing up! Your account is pending approval.</p>';
+        } else {
+          const data = await resp.json().catch(() => ({}));
+          alert(data.error || 'Sign up failed');
+        }
+      } catch (err) {
+        alert('Sign up failed');
+      }
+    });
+  }
+
   const contactForm = document.getElementById('contactForm');
   if (contactForm) {
     contactForm.addEventListener('submit', e => {
@@ -244,6 +286,25 @@ document.addEventListener('DOMContentLoaded', () => {
       try { await fetch('/api/logout', { method: 'POST' }); } catch(e) {}
       localStorage.removeItem('retailLoggedIn');
       window.location.href = 'retail-login.html';
+    });
+  }
+
+  const subForm = document.getElementById('subForm');
+  if (subForm) {
+    subForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const status = document.getElementById('subSelect').value;
+      try {
+        const resp = await fetch('/api/subscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status })
+        });
+        if (resp.ok) alert('Subscription updated');
+        else alert('Update failed');
+      } catch (err) {
+        alert('Update failed');
+      }
     });
   }
 });

--- a/signup.html
+++ b/signup.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Get in touch with the FindMySmokeShop team.">
-  <title>Contact Us | FindMySmokeShop</title>
+  <meta name="description" content="Create a FindMySmokeShop account">
+  <title>Sign Up | FindMySmokeShop</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -15,36 +15,31 @@
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
       <li><a href="index.html">Home</a></li>
-      <li><a href="brands.html" >Brands</a></li>
-      <li><a href="for-shops.html" >For Stores</a></li>
-      <li><a href="locator.html" >Store Locator</a></li>
-      <li><a href="login.html" >Login</a></li>
+      <li><a href="brands.html">Brands</a></li>
+      <li><a href="for-shops.html">For Stores</a></li>
+      <li><a href="locator.html">Store Locator</a></li>
+      <li><a href="login.html">Login</a></li>
     </ul>
   </nav>
   <button class="menuBtn" id="menuBtn" aria-label="Toggle menu"><span></span></button>
 </header>
-  <main class="main-centered padded">
-    <h1>Contact Us</h1>
-    <form id="contactForm" class="contact-form">
-      <div class="form-row">
-        <label>Name<br>
-          <input type="text" id="contactName" required>
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Email<br>
-          <input type="email" id="contactEmail" required>
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Message<br>
-          <textarea id="contactMessage" rows="4" required></textarea>
-        </label>
-      </div>
-      <button type="submit" class="btn btn--primary">Send</button>
-    </form>
-    <p id="contactStatus" class="mt-1"></p>
-  </main>
+<main class="main-centered main-centered--sm">
+  <h1>Create Account</h1>
+  <form id="signupForm" class="login-form">
+    <div class="form-row">
+      <label>Email<br>
+        <input type="email" id="signupEmail" required>
+      </label>
+    </div>
+    <div class="form-row">
+      <label>Password<br>
+        <input type="password" id="signupPassword" required>
+      </label>
+    </div>
+    <button type="submit" class="btn btn--primary">Sign Up</button>
+  </form>
+  <p class="small-text">Already have an account? <a href="login.html">Log in</a></p>
+</main>
 <footer class="siteFooter">
   <div class="footerInner">
     <div class="footerCol">
@@ -78,6 +73,6 @@
   </div>
   <p class="copy">© <span id="year">2025</span> FindMySmokeShop. All rights reserved.</p>
 </footer>
-  <script src="script.js" defer></script>
+<script src="script.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,10 @@ img{display:block;max-width:100%}
 .login-form input,.contact-form input,.contact-form textarea{width:100%;padding:.6rem .8rem;border:2px solid #ccc;border-radius:var(--radius);font-size:1rem}
 .login-form button,.contact-form button{align-self:center;padding:.6rem 1.5rem;font-size:1rem;font-weight:600;border:0;border-radius:var(--radius);background:var(--accent);color:#fff;cursor:pointer;transition:opacity var(--dur)}
 .login-form button:hover,.contact-form button:hover{opacity:.85}
+.subscriptionForm{display:flex;align-items:center;gap:1rem;margin-top:1.5rem}
+.subscriptionForm select{padding:.5rem .7rem;border:2px solid #ccc;border-radius:var(--radius)}
+.ageGate{position:fixed;inset:0;background:rgba(0,0,0,.9);display:flex;align-items:center;justify-content:center;z-index:1000}
+.ageGateBox{background:#fff;padding:2rem;border-radius:var(--radius);text-align:center;max-width:340px}
 .small-text{margin-top:1rem;font-size:.9rem}
 /* ---- Utility ---- */
 .main-centered{max-width:700px;margin:3rem auto;text-align:center;}

--- a/terms.html
+++ b/terms.html
@@ -14,6 +14,7 @@
   </a>
   <nav role="navigation">
     <ul class="navLinks" id="navLinks">
+      <li><a href="index.html">Home</a></li>
       <li><a href="brands.html" >Brands</a></li>
       <li><a href="for-shops.html" >For Stores</a></li>
       <li><a href="locator.html" >Store Locator</a></li>


### PR DESCRIPTION
## Summary
- add a Home link to the navigation bar on every page
- create `signup.html` and link to it from the login pages
- gate logins until an admin manually approves new accounts
- enable subscription management from the brand and retail portals
- prompt visitors to confirm they are 21+ before viewing the site

## Testing
- `python3 -m py_compile app.py backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688739c64b608328a66424d18963853a