### PR TITLE
Improve brand and retail dashboards

### DIFF
--- a/brand-portal.html
+++ b/brand-portal.html
@@ -25,12 +25,24 @@
 </header>
   <main class="infoWrap">
     <h1>Brand Dashboard</h1>
-    <ul>
-      <li><strong>Manage Products:</strong> add or edit your product listings.</li>
-      <li><strong>Update Brand Assets:</strong> upload new logos and images.</li>
-      <li><strong>View Analytics:</strong> see store leads and brand views.</li>
-    </ul>
-    <form id="subForm" class="subscriptionForm">
+    <div class="dashGrid">
+      <section class="dashCard">
+        <h2>Product Listings</h2>
+        <p>Add or edit the products displayed to stores.</p>
+        <button class="btn btn--primary">Manage Products</button>
+      </section>
+      <section class="dashCard">
+        <h2>Brand Assets</h2>
+        <p>Upload new logos and marketing materials.</p>
+        <button class="btn btn--primary">Upload Assets</button>
+      </section>
+      <section class="dashCard">
+        <h2>Your Stats</h2>
+        <p class="metric">Views: <span id="viewsCount">0</span></p>
+        <p class="metric">Leads: <span id="leadsCount">0</span></p>
+      </section>
+    </div>
+    <form id="subForm" class="subscriptionForm mt-1">
       <label>Subscription
         <select id="subSelect">
           <option value="none">None</option>

--- a/retail-portal.html
+++ b/retail-portal.html
@@ -25,12 +25,24 @@
 </header>
   <main class="infoWrap">
     <h1>Store Dashboard</h1>
-    <ul>
-      <li><strong>Update Inventory:</strong> manage the products you carry.</li>
-      <li><strong>Claim or Update Location:</strong> edit store details and hours.</li>
-      <li><strong>View Lead Stats:</strong> track customer inquiries and visits.</li>
-    </ul>
-    <form id="subForm" class="subscriptionForm">
+    <div class="dashGrid">
+      <section class="dashCard">
+        <h2>Inventory</h2>
+        <p>Manage the products stocked at your store.</p>
+        <button class="btn btn--primary">Update Inventory</button>
+      </section>
+      <section class="dashCard">
+        <h2>Location Details</h2>
+        <p>Edit your store hours and contact info.</p>
+        <button class="btn btn--primary">Edit Profile</button>
+      </section>
+      <section class="dashCard">
+        <h2>Your Stats</h2>
+        <p class="metric">Inquiries: <span id="inquiryCount">0</span></p>
+        <p class="metric">Visits: <span id="visitCount">0</span></p>
+      </section>
+    </div>
+    <form id="subForm" class="subscriptionForm mt-1">
       <label>Subscription
         <select id="subSelect">
           <option value="none">None</option>

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@
   --dur:.3s;
 }
 *{box-sizing:border-box;margin:0}
-body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;background:#fff;color:#222}
+body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;background:#f7f9fa;color:#222}
 img{display:block;max-width:100%}
 /* Hide elements visually but keep them accessible to screen readers */
 .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
@@ -50,7 +50,7 @@ img{display:block;max-width:100%}
 .productCard img{width:100%;height:120px;object-fit:contain}
 /* ---- Buttons ---- */
 .btn{display:inline-block;margin:.7rem 1rem;padding:.7rem 1.5rem;font-weight:700;border-radius:var(--radius);text-decoration:none;}
-.btn--primary{background:var(--accent);color:#fff;}
+.btn--primary{background:linear-gradient(135deg,var(--accent),#008294);color:#fff;}
 .btn--secondary{background:#fff;color:var(--accent);border:2px solid var(--accent);}
 .btn:hover{opacity:.9}
 /* ---- Footer ---- */
@@ -115,3 +115,9 @@ img{display:block;max-width:100%}
 .mt-1{margin-top:1rem;}
 .filterBar{max-width:var(--maxW);margin:2rem auto;padding:0 1rem;text-align:center;}
 .brandGrid{max-width:var(--maxW);margin:0 auto 3rem;padding:0 1rem;display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:1.5rem;justify-items:center;}
+
+/* ---- Dashboards ---- */
+.dashGrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1.5rem;margin-top:1.5rem;}
+.dashCard{background:#fafafa;border-radius:var(--radius);box-shadow:var(--shadow);padding:1.2rem;text-align:center;display:flex;flex-direction:column;gap:.8rem}
+.dashCard h2{font-size:1.25rem;color:var(--accent);}
+.metric{font-weight:600;margin-top:.5rem;}


### PR DESCRIPTION
## Summary
- refine dashboard layout for brands and stores
- add dashboard card styles and metrics placeholders
- apply subtle UI updates and gradient buttons

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68874899360883288f8792a157d49e63