### PR TITLE
Fix duplicated Store Locator link in footer

### DIFF
--- a/locator.html
+++ b/locator.html
@@ -60,7 +60,6 @@
         <li><a href="brands.html">Brands</a></li>
         <li><a href="for-shops.html">For Stores</a></li>
       <li><a href="locator.html" class="active">Store Locator</a></li>
-        <li><a href="locator.html">Store Locator</a></li>
         <li><a href="contact.html">Contact Us</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- delete redundant `Store Locator` link in locator footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887867fb8c483288a6e67861fd66dfd