### PR TITLE
Use SECRET_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ stored alongside the code.
 The brand and retail portals contain a small form that lets logged in users
 update their subscription level using the `/api/subscribe` endpoint.
 
-Set `SECRET_KEY` in `backend/app.py` to a strong value before deploying.
+Set the `SECRET_KEY` environment variable before running the server to keep
+session data secure. `backend/app.py` falls back to a default if this variable
+is missing.
 
 ## Deploying with cPanel Git
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,8 +8,8 @@ from flask_cors import CORS
 from werkzeug.security import generate_password_hash, check_password_hash
 
 app = Flask(__name__)
-# Replace this with a secure random value in production
-app.config['SECRET_KEY'] = 'change-me'
+# SECRET_KEY can be provided via environment variable for production
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change-me')
 CORS(app, supports_credentials=True)
 
 DB_PATH = Path(__file__).with_name('app.db')


### PR DESCRIPTION
## Summary
- read SECRET_KEY from env in backend/app.py
- document SECRET_KEY env variable in README

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68878675a8a483288efafe334e04da71