### PR TITLE
Add Dockerfile and update README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+__pycache__
+backend/app.db

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ Set the `SECRET_KEY` environment variable before running the server to keep
 session data secure. `backend/app.py` falls back to a default if this variable
 is missing.
 
+## Docker
+
+A `Dockerfile` under `backend/` can build a containerized version of the API.
+
+Build the image from the project root:
+
+```bash
+docker build -t findmysmokeshop-backend ./backend
+```
+
+Run the container and expose port 5000:
+
+```bash
+docker run -p 5000:5000 findmysmokeshop-backend
+```
+
+The API will be available at `http://localhost:5000/`.
+
 ## Deploying with cPanel Git
 
 cPanel includes a **Git Version Control** feature that can automatically pull your repository and run deployment commands.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "wsgi:application"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 Flask-Cors
 requests
+gunicorn


### PR DESCRIPTION
## Summary
- add Dockerfile for backend Flask app
- ignore git files, pycache and the database for Docker builds
- add gunicorn to requirements
- document how to build and run the Docker container in README

## Testing
- `python3 -m py_compile backend/app.py backend/wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_688995c96f288328933de6fd19f547d0