### PR TITLE
Add navigation guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions
+
+This project is a simple static website with a small Flask backend located in the `backend/` directory.
+
+## Workflow Guidelines
+
+- Make small, focused commits with descriptive messages.
+- After modifying any Python code, run the following syntax check from the repo root:
+
+  ```bash
+  python -m py_compile backend/app.py backend/wsgi.py
+  ```
+
+  Add any new Python files to this command as needed.
+- See `backend/AGENTS.md` for backend-specific details.
+
+## Navigation Tips
+
+- HTML, CSS and JavaScript files live in the repository root.
+- The Flask API code is under `backend/`.
+- `README.md` explains how to run the backend server and the static site.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,28 @@
+# Backend Agent Instructions
+
+This directory contains the Flask API used by the site.
+
+## Key Files
+
+- `app.py` – main Flask application.
+- `wsgi.py` – entry point for WSGI servers.
+- `requirements.txt` – Python dependencies.
+
+## Development Tips
+
+- Use Python 3.11 or later.
+- To run the server locally:
+
+  ```bash
+  flask --app app run
+  ```
+
+- Before committing any changes in this directory, run:
+
+  ```bash
+  python -m py_compile app.py wsgi.py
+  ```
+
+  Add any new modules to this command to ensure they compile.
+
+- The SQLite database `app.db` will be created automatically on first run.


### PR DESCRIPTION
## Summary
- document project layout with `AGENTS.md`
- add backend guidance in `backend/AGENTS.md`

## Testing
- `python -m py_compile backend/app.py backend/wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_688c4630d25c8328bb8138c0581a29d3